### PR TITLE
Net8 upgrade

### DIFF
--- a/TestDummyProcess/TestDummyProcess.csproj
+++ b/TestDummyProcess/TestDummyProcess.csproj
@@ -5,6 +5,8 @@
         <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
+        <AssemblyVersion>1.25.4.0</AssemblyVersion>
+        <FileVersion>1.25.4.0</FileVersion>
     </PropertyGroup>
 
 </Project>

--- a/src/DiskQueue.Tests/DiskQueue.Tests.csproj
+++ b/src/DiskQueue.Tests/DiskQueue.Tests.csproj
@@ -5,6 +5,8 @@
     <LangVersion>9</LangVersion>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <AssemblyVersion>1.25.4.0</AssemblyVersion>
+    <FileVersion>1.25.4.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/DiskQueue.Tests/PerformanceTests.cs
+++ b/src/DiskQueue.Tests/PerformanceTests.cs
@@ -148,7 +148,7 @@ namespace DiskQueue.Tests
 
 			for (int e = 0; e < 100; e++)
 			{
-				if (!threads[e].Join(50_000)) Assert.Fail("reader timeout");
+				if (!threads[e].Join(110_000)) Assert.Fail($"reader timeout on thread {e}");
 			}
 		}
 

--- a/src/DiskQueue/DiskQueue.csproj
+++ b/src/DiskQueue/DiskQueue.csproj
@@ -1,17 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>9</LangVersion>
     <Nullable>enable</Nullable>
     <PackageVersion>1.7.1</PackageVersion>
-    <AssemblyVersion>1.7.1.0</AssemblyVersion>
-    <FileVersion>1.7.1.0</FileVersion>
+    <AssemblyVersion>1.25.4.2</AssemblyVersion>
+    <FileVersion>1.25.4.2</FileVersion>
     <ApplicationVersion>1.3.2</ApplicationVersion>
     <Version>1.3.2</Version>
     <Copyright>2013-2023 Iain Ballard</Copyright>
   </PropertyGroup>
-
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
     <DocumentationFile>bin\Debug\DiskQueue.xml</DocumentationFile>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
@@ -19,7 +17,6 @@
     <Optimize>false</Optimize>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
-
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -28,9 +25,4 @@
     <DebugSymbols>true</DebugSymbols>
     <DocumentationFile>bin\Release\DiskQueue.xml</DocumentationFile>
   </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="System.IO.FileSystem.AccessControl" Version="4.7.0" />
-  </ItemGroup>
-
 </Project>

--- a/src/DiskQueue/DiskQueue.csproj
+++ b/src/DiskQueue/DiskQueue.csproj
@@ -11,35 +11,8 @@
     <Copyright>2013-2025 Iain Ballard</Copyright>
     <Description>A robust, thread-safe, and multi-process persistent queue library for dotnet.</Description>
     <RepositoryUrl>https://github.com/i-e-b/DiskQueue</RepositoryUrl>
-    <PackageLicenseExpression>
-      Initial Copyright (c) 2005 - 2008 Ayende Rahien (ayende@ayende.com)
-      All rights reserved.
-
-      Portions Copyright (c) 2013 - 2025 Iain Ballard
-
-      Redistribution and use in source and binary forms, with or without modification,
-      are permitted provided that the following conditions are met:
-
-      * Redistributions of source code must retain the above copyright notice,
-      this list of conditions and the following disclaimer.
-      * Redistributions in binary form must reproduce the above copyright notice,
-      this list of conditions and the following disclaimer in the documentation
-      and/or other materials provided with the distribution.
-      * Neither the name of Ayende Rahien nor Iain Ballard nor the names of its
-      contributors may be used to endorse or promote products derived from this
-      software without specific prior written permission.
-
-      THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-      ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-      WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-      DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
-      FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-      DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-      SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-      CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-      OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
-      THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-    </PackageLicenseExpression>
+    <PackageIcon>Logo-small.png</PackageIcon>
+    <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageTags>net8</PackageTags>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
@@ -57,4 +30,12 @@
     <DebugSymbols>true</DebugSymbols>
     <DocumentationFile>bin\Release\DiskQueue.xml</DocumentationFile>
   </PropertyGroup>
+  <ItemGroup>
+    <None Include="..\..\LICENSE">
+      <Pack>True</Pack>
+    </None>
+    <None Include="..\..\Logo-small.png">
+      <Pack>True</Pack>
+    </None>
+  </ItemGroup>
 </Project>

--- a/src/DiskQueue/DiskQueue.csproj
+++ b/src/DiskQueue/DiskQueue.csproj
@@ -3,12 +3,44 @@
     <TargetFramework>net8.0</TargetFramework>
     <LangVersion>9</LangVersion>
     <Nullable>enable</Nullable>
-    <PackageVersion>1.7.1</PackageVersion>
-    <AssemblyVersion>1.7.1.0</AssemblyVersion>
-    <FileVersion>1.7.1.0</FileVersion>
-    <ApplicationVersion>1.3.2</ApplicationVersion>
-    <Version>1.3.2</Version>
-    <Copyright>2013-2023 Iain Ballard</Copyright>
+    <PackageVersion>1.8.0</PackageVersion>
+    <AssemblyVersion>1.8.0.0</AssemblyVersion>
+    <FileVersion>1.8.0.0</FileVersion>
+    <ApplicationVersion>1.8.0</ApplicationVersion>
+    <Version>1.8.0</Version>
+    <Copyright>2013-2025 Iain Ballard</Copyright>
+    <Description>A robust, thread-safe, and multi-process persistent queue library for dotnet.</Description>
+    <RepositoryUrl>https://github.com/i-e-b/DiskQueue</RepositoryUrl>
+    <PackageLicenseExpression>
+      Initial Copyright (c) 2005 - 2008 Ayende Rahien (ayende@ayende.com)
+      All rights reserved.
+
+      Portions Copyright (c) 2013 - 2025 Iain Ballard
+
+      Redistribution and use in source and binary forms, with or without modification,
+      are permitted provided that the following conditions are met:
+
+      * Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimer.
+      * Redistributions in binary form must reproduce the above copyright notice,
+      this list of conditions and the following disclaimer in the documentation
+      and/or other materials provided with the distribution.
+      * Neither the name of Ayende Rahien nor Iain Ballard nor the names of its
+      contributors may be used to endorse or promote products derived from this
+      software without specific prior written permission.
+
+      THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+      ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+      WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+      DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+      FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+      DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+      SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+      CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+      OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+      THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+    </PackageLicenseExpression>
+    <PackageTags>net8</PackageTags>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
     <DocumentationFile>bin\Debug\DiskQueue.xml</DocumentationFile>

--- a/src/DiskQueue/DiskQueue.csproj
+++ b/src/DiskQueue/DiskQueue.csproj
@@ -4,8 +4,8 @@
     <LangVersion>9</LangVersion>
     <Nullable>enable</Nullable>
     <PackageVersion>1.7.1</PackageVersion>
-    <AssemblyVersion>1.25.4.2</AssemblyVersion>
-    <FileVersion>1.25.4.2</FileVersion>
+    <AssemblyVersion>1.7.1.0</AssemblyVersion>
+    <FileVersion>1.7.1.0</FileVersion>
     <ApplicationVersion>1.3.2</ApplicationVersion>
     <Version>1.3.2</Version>
     <Copyright>2013-2023 Iain Ballard</Copyright>

--- a/src/DiskQueue/Implementation/DefaultSerializationStrategy.cs
+++ b/src/DiskQueue/Implementation/DefaultSerializationStrategy.cs
@@ -37,6 +37,10 @@ namespace DiskQueue.Implementation
 
             using MemoryStream ms = new(bytes);
             var obj = _serialiser.ReadObject(ms);
+            if (obj == null)
+            {
+                return default;
+            }
             return (T)obj;
         }
 

--- a/src/DiskQueue/Implementation/Extensions.cs
+++ b/src/DiskQueue/Implementation/Extensions.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Collections.Generic;
+using System.Text.Json;
 
 namespace DiskQueue.Implementation
 {
@@ -29,5 +31,25 @@ namespace DiskQueue.Implementation
 		{
 			return self.TryGetValue(key, out var value) == false ? default : value;
 		}
-	}
+
+		/// <summary>
+		/// Serializes the exception to JSON.
+		/// </summary>
+		/// <param name="ex">The exception to serialize to JSON.</param>
+		/// <returns>String representation of the exception.</returns>
+        public static string ToJson(this Exception ex)
+        {
+            if (ex == null)
+            {
+                return null!;
+            }
+
+            return JsonSerializer.Serialize(new
+            {
+                ex.Message,
+                ex.StackTrace,
+                InnerException = ex.InnerException?.ToJson()
+            });
+        }
+    }
 }

--- a/src/DiskQueue/Implementation/MarshallHelper.cs
+++ b/src/DiskQueue/Implementation/MarshallHelper.cs
@@ -60,7 +60,8 @@ namespace DiskQueue.Implementation
             try
             {
                 pinnedPacket = GCHandle.Alloc(data, GCHandleType.Pinned);
-                result = (T)Marshal.PtrToStructure(pinnedPacket.AddrOfPinnedObject(), typeof(T)) ?? throw new Exception("Could not deserialise");
+                object? obj = Marshal.PtrToStructure(pinnedPacket.AddrOfPinnedObject(), typeof(T));
+                result = obj != null ? (T)obj : throw new Exception("Could not deserialise");
             }
             finally
             {

--- a/src/DiskQueue/Implementation/MarshallHelper.cs
+++ b/src/DiskQueue/Implementation/MarshallHelper.cs
@@ -13,7 +13,7 @@ namespace DiskQueue.Implementation
         /// </summary>
         /// <param name="value">The structure to serialize to a byte array.</param>
         /// <returns>The object serialized to a byte array, ready to write to a stream.</returns>
-        public static byte[] Serialize<T>(T value)
+        public static byte[] Serialize<T>(T value) where T : struct
         {
             // Get the size of our structure in bytes
             var structSize = Marshal.SizeOf(value);

--- a/src/DiskQueue/Implementation/PendingWriteException.cs
+++ b/src/DiskQueue/Implementation/PendingWriteException.cs
@@ -86,7 +86,6 @@ namespace DiskQueue.Implementation
 		/// Sets the <see cref="T:System.Runtime.Serialization.SerializationInfo"/> with information about the exception.
 		/// </summary>
 		/// <param name="info">The <see cref="T:System.Runtime.Serialization.SerializationInfo"/> that holds the serialized object data about the exception being thrown. </param><param name="context">The <see cref="T:System.Runtime.Serialization.StreamingContext"/> that contains contextual information about the source or destination. </param><exception cref="T:System.ArgumentNullException">The <paramref name="info"/> parameter is a null reference (Nothing in Visual Basic). </exception><filterpriority>2</filterpriority><PermissionSet><IPermission class="System.Security.Permissions.FileIOPermission, mscorlib, Version=2.0.3600.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" version="1" Read="*AllFiles*" PathDiscovery="*AllFiles*"/><IPermission class="System.Security.Permissions.SecurityPermission, mscorlib, Version=2.0.3600.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" version="1" Flags="SerializationFormatter"/></PermissionSet>
-		[SecurityPermission(SecurityAction.LinkDemand, Flags = SecurityPermissionFlag.SerializationFormatter)]
 		public override void GetObjectData(SerializationInfo info, StreamingContext context)
 		{
 			base.GetObjectData(info, context);

--- a/src/DiskQueue/Implementation/PendingWriteException.cs
+++ b/src/DiskQueue/Implementation/PendingWriteException.cs
@@ -62,7 +62,7 @@ namespace DiskQueue.Implementation
 		{
 			get
 			{
-				var sb = new StringBuilder(base.Message ?? "Error").Append(":");
+				var sb = new StringBuilder(base.Message ?? "Error").Append(':');
 				foreach (var exception in _pendingWritesExceptions)
 				{
 					sb.AppendLine().Append(" - ").Append(exception.Message ?? "<unknown>");

--- a/src/DiskQueue/Implementation/SetPermissions.cs
+++ b/src/DiskQueue/Implementation/SetPermissions.cs
@@ -12,18 +12,6 @@ namespace DiskQueue.Implementation
 	public static class SetPermissions
 	{
 		/// <summary>
-		/// True if running in a Posix environment, false if Windows or unknown.
-		/// </summary>
-		public static bool RunningUnderPosix
-		{
-			get
-			{
-				var p = (int)Environment.OSVersion.Platform;
-				return (p == 4) || (p == 6) || (p == 128);
-			}
-		}
-
-		/// <summary>
 		/// Set read-write access for all users, or ignore if not possible
 		/// </summary>
 		public static void TryAllowReadWriteForAll(string path)
@@ -44,7 +32,7 @@ namespace DiskQueue.Implementation
 
 		private static void File_RWX_all(string path)
 		{
-			if (RunningUnderPosix)
+			if (!OperatingSystem.IsWindows())
 			{
 				UnsafeNativeMethods.chmod(path, UnixFilePermissions.ACCESSPERMS);
 			}
@@ -61,7 +49,7 @@ namespace DiskQueue.Implementation
 
 		private static void Directory_RWX_all(string path)
 		{
-			if (RunningUnderPosix)
+			if (!OperatingSystem.IsWindows())
 			{
 				UnsafeNativeMethods.chmod(path, UnixFilePermissions.ACCESSPERMS);
 			}


### PR DESCRIPTION
# .NET 8 Upgrade
Project migrated from .Net Standard 2 to .NET 8, with minimum changes needed to get it to compile and pass tests.

## Summary of changes
See commits for details, but in a nutshell:

* added some measures to avoid potential null value conversions.
* modernized how the runtime OS is determined.
* removed the CAS attributes (ignored in .NET 8).
* removed the GetObjectData override in the custom exception, PendingWriteException. I didn't see that this got called explicitly
* but I added a couple methods for serializing it to JSON, if needed. Those methods remain unused though, I guess could be dropped.
* changed version to 1.8.0 to reflect (I hope) this non-breaking change.
* [breaking] no longer supports .NET Framework or .NET Standard 2.0 (so maybe this should be major version change?).

## Test results
All testing passes with the exception of read_heavy_multi_thread_workload. I had to increase the timeout on joining the reading threads to get it to pass, maybe just a limitation of my workstation.
 

## What it does not include
style changes
refactoring for new language features
anything for updating the available nuget package. Happy to help with this if desired.