### PR TITLE
Upgrade nunit

### DIFF
--- a/src/ModernDiskQueue.Tests/ConstantChecks.cs
+++ b/src/ModernDiskQueue.Tests/ConstantChecks.cs
@@ -10,13 +10,13 @@ namespace ModernDiskQueue.Tests
         public void StartTransactionSeparatorGuid_is_undamaged()
         {
             // This should never be changed! If this test fails existing queues will be unreadable.
-            Assert.AreEqual("b75bfb12-93bb-42b6-acb1-a897239ea3a5", Constants.StartTransactionSeparatorGuid.ToString());
+            Assert.That("b75bfb12-93bb-42b6-acb1-a897239ea3a5", Is.EqualTo(Constants.StartTransactionSeparatorGuid.ToString()));
         }
         [Test]
         public void EndTransactionSeparatorGuid_is_undamaged()
         {
             // This should never be changed! If this test fails existing queues will be unreadable.
-            Assert.AreEqual("866c9705-4456-4e9d-b452-3146b3bfa4ce", Constants.EndTransactionSeparatorGuid.ToString());
+            Assert.That("866c9705-4456-4e9d-b452-3146b3bfa4ce", Is.EqualTo(Constants.EndTransactionSeparatorGuid.ToString()));
         }
     }
 }

--- a/src/ModernDiskQueue.Tests/CountOfItemsPersistentQueueTests.cs
+++ b/src/ModernDiskQueue.Tests/CountOfItemsPersistentQueueTests.cs
@@ -13,7 +13,7 @@ namespace ModernDiskQueue.Tests
 		{
 			using (var queue = new PersistentQueue(Path))
 			{
-				Assert.AreEqual(0, queue.EstimatedCountOfItemsInQueue);
+				Assert.That(0, Is.EqualTo(queue.EstimatedCountOfItemsInQueue));
 			}
 		}
 
@@ -30,7 +30,7 @@ namespace ModernDiskQueue.Tests
 						session.Flush();
 					}
 				}
-				Assert.AreEqual(5, queue.EstimatedCountOfItemsInQueue);
+				Assert.That(5, Is.EqualTo(queue.EstimatedCountOfItemsInQueue));
 			}
 		}
 
@@ -52,7 +52,7 @@ namespace ModernDiskQueue.Tests
 
 			using (var queue = new PersistentQueue(Path))
 			{
-				Assert.AreEqual(5, queue.EstimatedCountOfItemsInQueue);
+				Assert.That(5, Is.EqualTo(queue.EstimatedCountOfItemsInQueue));
 			}
 		}
 	}

--- a/src/ModernDiskQueue.Tests/GenericQueueTests.cs
+++ b/src/ModernDiskQueue.Tests/GenericQueueTests.cs
@@ -22,7 +22,7 @@ namespace ModernDiskQueue.Tests
             session.Flush();
             var testNumber = session.Dequeue();
             session.Flush();
-            Assert.AreEqual(7, testNumber);
+            Assert.That(7, Is.EqualTo(testNumber));
         }
 
         [TestCase("Test")]
@@ -45,7 +45,7 @@ namespace ModernDiskQueue.Tests
             session.Flush();
             var returnValue = session.Dequeue();
             session.Flush();
-            Assert.AreEqual(valueToTest, returnValue);
+            Assert.That(valueToTest, Is.EqualTo(returnValue));
         }
 
         [Test]
@@ -60,7 +60,7 @@ namespace ModernDiskQueue.Tests
             var testObject2 = session.Dequeue();
             session.Flush();
             Assert.IsNotNull(testObject2);
-            Assert.AreEqual(testObject,testObject2);
+            Assert.That(testObject, Is.EqualTo(testObject2));
 
             testObject = new TestClass(7, "TestString", -5);
             session.Enqueue(testObject);
@@ -68,7 +68,7 @@ namespace ModernDiskQueue.Tests
             testObject2 = session.Dequeue();
             session.Flush();
             Assert.IsNotNull(testObject2);
-            Assert.AreEqual(testObject, testObject2);
+            Assert.That(testObject, Is.EqualTo(testObject2));
         }
 
         [Test]
@@ -83,7 +83,7 @@ namespace ModernDiskQueue.Tests
             var testObject2 = session.Dequeue();
             session.Flush();
             Assert.IsNotNull(testObject2);
-            Assert.AreEqual(testObject,testObject2);
+            Assert.That(testObject, Is.EqualTo(testObject2));
         }
     }
 

--- a/src/ModernDiskQueue.Tests/GenericQueueTests.cs
+++ b/src/ModernDiskQueue.Tests/GenericQueueTests.cs
@@ -59,7 +59,7 @@ namespace ModernDiskQueue.Tests
             session.Flush();
             var testObject2 = session.Dequeue();
             session.Flush();
-            Assert.IsNotNull(testObject2);
+            Assert.That(testObject2, Is.Not.Null);
             Assert.That(testObject, Is.EqualTo(testObject2));
 
             testObject = new TestClass(7, "TestString", -5);
@@ -67,7 +67,7 @@ namespace ModernDiskQueue.Tests
             session.Flush();
             testObject2 = session.Dequeue();
             session.Flush();
-            Assert.IsNotNull(testObject2);
+            Assert.That(testObject2, Is.Not.Null);
             Assert.That(testObject, Is.EqualTo(testObject2));
         }
 
@@ -82,7 +82,7 @@ namespace ModernDiskQueue.Tests
             session.Flush();
             var testObject2 = session.Dequeue();
             session.Flush();
-            Assert.IsNotNull(testObject2);
+            Assert.That(testObject2, Is.Not.Null);
             Assert.That(testObject, Is.EqualTo(testObject2));
         }
     }

--- a/src/ModernDiskQueue.Tests/LockFileDataSerializationTest.cs
+++ b/src/ModernDiskQueue.Tests/LockFileDataSerializationTest.cs
@@ -26,7 +26,7 @@ namespace ModernDiskQueue.Tests
             var actual = MarshallHelper.Serialize(data);
             for (var i = 0; i < expected.Length && i < actual.Length; i++)
             {
-                Assert.AreEqual(expected[i], actual[i]);
+                Assert.That(expected[i], Is.EqualTo(actual[i]));
             }
         }
 
@@ -41,9 +41,9 @@ namespace ModernDiskQueue.Tests
             };
 
             var actual = MarshallHelper.Deserialize<LockFileData>(input);
-            Assert.AreEqual(8 + 256 * 1, actual.ProcessId);
-            Assert.AreEqual(16 + 256 * 2, actual.ThreadId);
-            Assert.AreEqual(0, actual.ProcessStart);
+            Assert.That(8 + 256 * 1, Is.EqualTo(actual.ProcessId));
+            Assert.That(16 + 256 * 2, Is.EqualTo(actual.ThreadId));
+            Assert.That(0, Is.EqualTo(actual.ProcessStart));
         }
 
         [Test]
@@ -57,9 +57,9 @@ namespace ModernDiskQueue.Tests
             };
 
             var actual = MarshallHelper.Deserialize<LockFileData>(input);
-            Assert.AreEqual(8 + 256 * 1, actual.ProcessId);
-            Assert.AreEqual(16 + 256 * 2, actual.ThreadId);
-            Assert.AreEqual(32 + 256 * 4, actual.ProcessStart);
+            Assert.That(8 + 256 * 1, Is.EqualTo(actual.ProcessId));
+            Assert.That(16 + 256 * 2, Is.EqualTo(actual.ThreadId));
+            Assert.That(32 + 256 * 4, Is.EqualTo(actual.ProcessStart));
         }
     }
 }

--- a/src/ModernDiskQueue.Tests/ModernDiskQueue.Tests.csproj
+++ b/src/ModernDiskQueue.Tests/ModernDiskQueue.Tests.csproj
@@ -11,10 +11,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="microsoft.net.test.sdk" Version="16.7.1" />
-    <PackageReference Include="nsubstitute" Version="4.0.0" />
-    <PackageReference Include="nunit" Version="3.12.0" />
-    <PackageReference Include="nunit3testadapter" Version="3.17.0" />
+    <PackageReference Include="microsoft.net.test.sdk" Version="17.13.0" />
+    <PackageReference Include="nsubstitute" Version="5.3.0" />
+    <PackageReference Include="nunit" Version="4.3.2" />
+    <PackageReference Include="nunit3testadapter" Version="5.0.0" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 

--- a/src/ModernDiskQueue.Tests/MultiFileQueueTests.cs
+++ b/src/ModernDiskQueue.Tests/MultiFileQueueTests.cs
@@ -14,7 +14,7 @@ namespace ModernDiskQueue.Tests
 		{
 			using (IPersistentQueue queue = new PersistentQueue(Path, 10))
 			{
-                Assert.AreEqual(10, queue.MaxFileSize);
+                Assert.That(10, Is.EqualTo(queue.MaxFileSize));
 			}
 		}
 
@@ -31,7 +31,7 @@ namespace ModernDiskQueue.Tests
 						session.Flush();
 					}
 				}
-				Assert.AreEqual(11, queue.EstimatedCountOfItemsInQueue);
+				Assert.That(11, Is.EqualTo(queue.EstimatedCountOfItemsInQueue));
 			}
 		}
 
@@ -48,7 +48,7 @@ namespace ModernDiskQueue.Tests
 						session.Flush();
 					}
 				}
-				Assert.AreEqual(1, queue.Internals.CurrentFileNumber);
+				Assert.That(1, Is.EqualTo(queue.Internals.CurrentFileNumber));
 			}
 		}
 
@@ -65,7 +65,7 @@ namespace ModernDiskQueue.Tests
 						session.Flush();
 					}
 				}
-				Assert.AreEqual(1, queue.Internals.CurrentFileNumber);
+				Assert.That(1, Is.EqualTo(queue.Internals.CurrentFileNumber));
 			}
 			using (var queue = new PersistentQueue(Path, 10))
 			{
@@ -77,7 +77,7 @@ namespace ModernDiskQueue.Tests
 						session.Flush();
 					}
 				}
-				Assert.AreEqual(1, queue.Internals.CurrentFileNumber);
+				Assert.That(1, Is.EqualTo(queue.Internals.CurrentFileNumber));
 			}
 		}
 
@@ -94,7 +94,7 @@ namespace ModernDiskQueue.Tests
 						session.Flush();
 					}
 				}
-				Assert.AreEqual(1, queue.Internals.CurrentFileNumber);
+				Assert.That(1, Is.EqualTo(queue.Internals.CurrentFileNumber));
 			}
 
 			using (var queue = new PersistentQueue(Path, 10))
@@ -103,7 +103,7 @@ namespace ModernDiskQueue.Tests
 				{
 					using (var session = queue.OpenSession())
 					{
-						Assert.AreEqual(i, session.Dequeue()?[0]);
+						Assert.That(i, Is.EqualTo(session.Dequeue()?[0]));
 						session.Flush();
 					}
 				}
@@ -123,7 +123,7 @@ namespace ModernDiskQueue.Tests
 						session.Flush();
 					}
 				}
-				Assert.AreEqual(1, queue.Internals.CurrentFileNumber);
+				Assert.That(1, Is.EqualTo(queue.Internals.CurrentFileNumber));
 			}
 
 			using (var queue = new PersistentQueue(Path, 10))
@@ -136,7 +136,7 @@ namespace ModernDiskQueue.Tests
 						session.Flush();
 					}
 				}
-				Assert.AreEqual(1, queue.Internals.CurrentFileNumber);
+				Assert.That(1, Is.EqualTo(queue.Internals.CurrentFileNumber));
 			}
 
 
@@ -146,13 +146,13 @@ namespace ModernDiskQueue.Tests
 				{
 					for (byte i = 0; i < 12; i++)
 					{
-						Assert.AreEqual(i, session.Dequeue()?[0]);
+						Assert.That(i, Is.EqualTo(session.Dequeue()?[0]));
 						session.Flush();
 					}
 
 					for (byte i = 0; i < 3; i++)
 					{
-						Assert.AreEqual(i, session.Dequeue()?[0]);
+						Assert.That(i, Is.EqualTo(session.Dequeue()?[0]));
 						session.Flush();
 					}
 				}
@@ -172,7 +172,7 @@ namespace ModernDiskQueue.Tests
 						session.Flush();
 					}
 				}
-				Assert.AreEqual(1, queue.Internals.CurrentFileNumber);
+				Assert.That(1, Is.EqualTo(queue.Internals.CurrentFileNumber));
 			}
 
 			using (var queue = new PersistentQueue(Path, 10))
@@ -181,7 +181,7 @@ namespace ModernDiskQueue.Tests
 				{
 					using (var session = queue.OpenSession())
 					{
-						Assert.AreEqual(i, session.Dequeue()?[0]);
+						Assert.That(i, Is.EqualTo(session.Dequeue()?[0]));
 						session.Flush();
 					}
 				}

--- a/src/ModernDiskQueue.Tests/MultiFileQueueTests.cs
+++ b/src/ModernDiskQueue.Tests/MultiFileQueueTests.cs
@@ -187,8 +187,8 @@ namespace ModernDiskQueue.Tests
 				}
 			}
 
-			Assert.IsFalse(
-				File.Exists(System.IO.Path.Combine(Path, "data.0"))
+			Assert.That(
+				File.Exists(System.IO.Path.Combine(Path, "data.0")), Is.False
 				);
 		}
 	}

--- a/src/ModernDiskQueue.Tests/PendingWriteExceptionTests.cs
+++ b/src/ModernDiskQueue.Tests/PendingWriteExceptionTests.cs
@@ -18,8 +18,8 @@ namespace ModernDiskQueue.Tests
 			catch (Exception e)
 			{
 				var s = new PendingWriteException(new []{e}).ToString();
-				Assert.IsTrue(
-					s.Contains(e.ToString())
+				Assert.That(
+					s.Contains(e.ToString()), Is.True
 					);
 			}
 		}
@@ -34,8 +34,8 @@ namespace ModernDiskQueue.Tests
 			catch (Exception e)
 			{
 				var s = new PendingWriteException(new [] { e });
-				Assert.IsTrue(
-					s.PendingWritesExceptions.Contains(e)
+				Assert.That(
+					s.PendingWritesExceptions.Contains(e), Is.True
 					);
 			}
 		}

--- a/src/ModernDiskQueue.Tests/PerformanceTests.cs
+++ b/src/ModernDiskQueue.Tests/PerformanceTests.cs
@@ -148,7 +148,7 @@ namespace ModernDiskQueue.Tests
 
 			for (int e = 0; e < 100; e++)
 			{
-				if (!threads[e].Join(110_000)) Assert.Fail($"reader timeout on thread {e}");
+				if (!threads[e].Join(150_000)) Assert.Fail($"reader timeout on thread {e}");
 			}
 		}
 

--- a/src/ModernDiskQueue.Tests/PerformanceTests.cs
+++ b/src/ModernDiskQueue.Tests/PerformanceTests.cs
@@ -233,7 +233,7 @@ namespace ModernDiskQueue.Tests
 				{
 					for (int i = 0; i < SmallCount; i++)
 					{
-						Assert.AreEqual(itemsSizes[i], session.Dequeue()?.Length ?? -1);
+						Assert.That(itemsSizes[i], Is.EqualTo(session.Dequeue()?.Length ?? -1));
 					}
 
 					session.Flush();

--- a/src/ModernDiskQueue.Tests/PersistentQueueSessionTests.cs
+++ b/src/ModernDiskQueue.Tests/PersistentQueueSessionTests.cs
@@ -150,7 +150,7 @@ namespace ModernDiskQueue.Tests
             
             Console.WriteLine(string.Join(", ", corruptBytes.OrEmpty().Select(b=>b.ToString())));
             Console.WriteLine(string.Join(", ", bytes.OrEmpty().Select(b=>b.ToString())));
-            CollectionAssert.AreEqual(new byte[] { 5,6,7,8 }, bytes!);
+            Assert.That(bytes!, Is.EqualTo(new byte[] { 5, 6, 7, 8 }));
         }
 
         private static IPersistentQueueImpl PersistentQueueWithMemoryStream(IFileStream limitedSizeStream)

--- a/src/ModernDiskQueue.Tests/PersistentQueueTests.cs
+++ b/src/ModernDiskQueue.Tests/PersistentQueueTests.cs
@@ -75,7 +75,7 @@ namespace ModernDiskQueue.Tests
 			using (var queue = new PersistentQueue(Path))
 			using (var session = queue.OpenSession())
 			{
-				Assert.IsNull(session.Dequeue());
+				Assert.That(session.Dequeue(), Is.Null);
 			}
 		}
 
@@ -146,7 +146,7 @@ namespace ModernDiskQueue.Tests
 			using (var session = queue.OpenSession())
 			{
 				Assert.That(session.Dequeue(), Is.EqualTo(new byte[] { 1, 2, 3, 4 }));
-				Assert.IsNull(session.Dequeue());
+				Assert.That(session.Dequeue(), Is.Null);
 				session.Flush();
 			}
 		}
@@ -171,7 +171,7 @@ namespace ModernDiskQueue.Tests
 			using (var queue = new PersistentQueue(Path))
 			using (var session = queue.OpenSession())
 			{
-				Assert.IsNull(session.Dequeue());
+				Assert.That(session.Dequeue(), Is.Null);
 				session.Flush();
 			}
 		}
@@ -256,7 +256,7 @@ namespace ModernDiskQueue.Tests
 			using (var session1 = queue.OpenSession())
 			{
 				Assert.That(session1.Dequeue(), Is.EqualTo(new byte[] { 1, 2, 3, 4 }));
-				Assert.IsNull(session2.Dequeue());
+				Assert.That(session2.Dequeue(), Is.Null);
 			}
 		}
 

--- a/src/ModernDiskQueue.Tests/PersistentQueueTests.cs
+++ b/src/ModernDiskQueue.Tests/PersistentQueueTests.cs
@@ -98,7 +98,7 @@ namespace ModernDiskQueue.Tests
 			{
 				session.Enqueue(new byte[] { 1, 2, 3, 4 });
 				session.Flush();
-				CollectionAssert.AreEqual(new byte[] { 1, 2, 3, 4 }, session.Dequeue());
+				Assert.That(session.Dequeue(), Is.EqualTo(new byte[] { 1, 2, 3, 4 }));
 			}
 		}
 
@@ -110,7 +110,7 @@ namespace ModernDiskQueue.Tests
 			{
 				session.Enqueue(new byte[0]);
 				session.Flush();
-				CollectionAssert.AreEqual(new byte[0], session.Dequeue());
+				Assert.That(session.Dequeue(), Is.EqualTo(Array.Empty<byte>()));
 			}
 		}
 
@@ -127,7 +127,7 @@ namespace ModernDiskQueue.Tests
 			using (var queue = new PersistentQueue(Path))
 			using (var session = queue.OpenSession())
 			{
-				CollectionAssert.AreEqual(new byte[] { 1, 2, 3, 4 }, session.Dequeue());
+				Assert.That(session.Dequeue(), Is.EqualTo(new byte[] { 1, 2, 3, 4 }));
 				session.Flush();
 			}
 		}
@@ -145,7 +145,7 @@ namespace ModernDiskQueue.Tests
 			using (var queue = new PersistentQueue(Path))
 			using (var session = queue.OpenSession())
 			{
-				CollectionAssert.AreEqual(new byte[] { 1, 2, 3, 4 }, session.Dequeue());
+				Assert.That(session.Dequeue(), Is.EqualTo(new byte[] { 1, 2, 3, 4 }));
 				Assert.IsNull(session.Dequeue());
 				session.Flush();
 			}
@@ -164,7 +164,7 @@ namespace ModernDiskQueue.Tests
 			using (var queue = new PersistentQueue(Path))
 			using (var session = queue.OpenSession())
 			{
-				CollectionAssert.AreEqual(new byte[] { 1, 2, 3, 4 }, session.Dequeue());
+				Assert.That(session.Dequeue(), Is.EqualTo(new byte[] { 1, 2, 3, 4 }));
 				session.Flush();
 			}
 
@@ -189,14 +189,14 @@ namespace ModernDiskQueue.Tests
 			using (var queue = new PersistentQueue(Path))
 			using (var session = queue.OpenSession())
 			{
-				CollectionAssert.AreEqual(new byte[] { 1, 2, 3, 4 }, session.Dequeue());
+				Assert.That(session.Dequeue(), Is.EqualTo(new byte[] { 1, 2, 3, 4 }));
 				//Explicitly omitted: session.Flush();
 			}
 
 			using (var queue = new PersistentQueue(Path))
 			using (var session = queue.OpenSession())
 			{
-				CollectionAssert.AreEqual(new byte[] { 1, 2, 3, 4 }, session.Dequeue());
+				Assert.That(session.Dequeue(), Is.EqualTo(new byte[] { 1, 2, 3, 4 }));
 				session.Flush();
 			}
 		}
@@ -233,10 +233,10 @@ namespace ModernDiskQueue.Tests
 			{
 				using (var session1 = queue.OpenSession())
 				{
-					CollectionAssert.AreEqual(new byte[] { 1, 2, 3, 4 }, session1.Dequeue());
+					Assert.That(session1.Dequeue(), Is.EqualTo(new byte[] { 1, 2, 3, 4 }));
 					//Explicitly omitted: session.Flush();
 				}
-				CollectionAssert.AreEqual(new byte[] { 1, 2, 3, 4 }, session2.Dequeue());
+				Assert.That(session2.Dequeue(), Is.EqualTo(new byte[] { 1, 2, 3, 4 }));
 				session2.Flush();
 			}
 		}
@@ -255,7 +255,7 @@ namespace ModernDiskQueue.Tests
 			using (var session2 = queue.OpenSession())
 			using (var session1 = queue.OpenSession())
 			{
-				CollectionAssert.AreEqual(new byte[] { 1, 2, 3, 4 }, session1.Dequeue());
+				Assert.That(session1.Dequeue(), Is.EqualTo(new byte[] { 1, 2, 3, 4 }));
 				Assert.IsNull(session2.Dequeue());
 			}
 		}
@@ -278,9 +278,9 @@ namespace ModernDiskQueue.Tests
                 using (var queue = new PersistentQueue(Path))
                 using (var session = queue.OpenSession())
                 {
-                    CollectionAssert.AreEqual(new byte[] { 1 }, session.Dequeue(), "Incorrect order on turn " + (i + 1));
-                    CollectionAssert.AreEqual(new byte[] { 2 }, session.Dequeue(), "Incorrect order on turn " + (i + 1));
-                    CollectionAssert.AreEqual(new byte[] { 3 }, session.Dequeue(), "Incorrect order on turn " + (i + 1));
+                    Assert.That(session.Dequeue(), Is.EqualTo(new byte[] { 1 }), $"Incorrect order on turn {i + 1}");
+					Assert.That(session.Dequeue(), Is.EqualTo(new byte[] { 2 }), $"Incorrect order on turn {i + 1}");
+                    Assert.That(session.Dequeue(), Is.EqualTo(new byte[] { 3 }), $"Incorrect order on turn {i + 1}");
                     // Dispose without `session.Flush();`
                 }
             }

--- a/src/ModernDiskQueue.Tests/TransactionLogTests.cs
+++ b/src/ModernDiskQueue.Tests/TransactionLogTests.cs
@@ -311,7 +311,7 @@ namespace ModernDiskQueue.Tests
 	            {
 	                for (int j = 0; j < 20; j++)
 	                {
-	                    session.Enqueue(new byte[0]);
+	                    session.Enqueue([]);
 	                    session.Flush();
 	                }
 	            }
@@ -396,11 +396,11 @@ namespace ModernDiskQueue.Tests
 		        queue.TrimTransactionLogOnDispose = false;
 		        using (var session = queue.OpenSession())
 	            {
-	                session.Enqueue(new byte[0]);
+	                session.Enqueue([]);
 	                session.Flush();
 	                for (int j = 0; j < 19; j++)
 	                {
-	                    session.Enqueue(new byte[] {1});
+	                    session.Enqueue([1]);
 	                    session.Flush();
 	                }
 	            }
@@ -431,10 +431,10 @@ namespace ModernDiskQueue.Tests
 	            {
 	                for (int j = 0; j < 19; j++)
 	                {
-	                    session.Enqueue(new byte[] {1});
+	                    session.Enqueue([1]);
 	                    session.Flush();
 	                }
-	                session.Enqueue(new byte[0]);
+	                session.Enqueue([]);
 	                session.Flush();
 	            }
 	        }
@@ -465,7 +465,7 @@ namespace ModernDiskQueue.Tests
 	            {
 	                for (int j = 0; j < 5; j++)
 	                {
-	                    session.Enqueue(new[]{(byte)(j+1)});
+	                    session.Enqueue([(byte)(j+1)]);
 	                }
                     session.Flush();
                 }
@@ -487,12 +487,12 @@ namespace ModernDiskQueue.Tests
 	            {
 	                for (int j = 0; j < 5; j++)
 	                {
-	                    Assert.That(session.Dequeue(), Is.EquivalentTo(new[]{(byte)(j+1)}));
+	                    Assert.That(session.Dequeue(), Is.EquivalentTo([(byte)(j+1)]));
 	                    session.Flush();
 	                }
 	                for (int j = 0; j < 5; j++)
 	                {
-		                Assert.That(session.Dequeue(), Is.EquivalentTo(new[]{(byte)(j+1)}));
+		                Assert.That(session.Dequeue(), Is.EquivalentTo([(byte)(j+1)]));
 		                session.Flush();
 	                }
 	                
@@ -514,7 +514,7 @@ namespace ModernDiskQueue.Tests
 	            {
 	                for (int j = 0; j < 5; j++)
 	                {
-	                    session.Enqueue(Array.Empty<byte>());
+	                    session.Enqueue([]);
 	                }
 	                session.Flush();
 	            }

--- a/src/ModernDiskQueue.Tests/TransactionLogTests.cs
+++ b/src/ModernDiskQueue.Tests/TransactionLogTests.cs
@@ -65,7 +65,7 @@ namespace ModernDiskQueue.Tests
 					{
 						session.Dequeue();
 					}
-					Assert.IsNull(session.Dequeue());
+					Assert.That(session.Dequeue(), Is.Null);
 
 					//	session.Flush(); explicitly removed
 				}
@@ -96,7 +96,7 @@ namespace ModernDiskQueue.Tests
 					{
 						session.Dequeue();
 					}
-					Assert.IsNull(session.Dequeue());
+					Assert.That(session.Dequeue(), Is.Null);
 
 					//	session.Flush(); explicitly removed
 				}
@@ -109,7 +109,7 @@ namespace ModernDiskQueue.Tests
 					{
 						session.Dequeue();
 					}
-					Assert.IsNull(session.Dequeue());
+					Assert.That(session.Dequeue(), Is.Null);
 					session.Flush();
 				}
 			}
@@ -143,7 +143,7 @@ namespace ModernDiskQueue.Tests
 				{
 					session.Dequeue();
 				}
-				Assert.IsNull(session.Dequeue());
+				Assert.That(session.Dequeue(), Is.Null);
 
 				session.Flush();
 			}
@@ -187,7 +187,7 @@ namespace ModernDiskQueue.Tests
 						var bytes = session.Dequeue() ?? throw new Exception("read failed");
 						Assert.That(j, Is.EqualTo(BitConverter.ToInt32(bytes, 0)));
 					}
-					Assert.IsNull(session.Dequeue());// the last transaction was corrupted
+					Assert.That(session.Dequeue(), Is.Null);// the last transaction was corrupted
 					session.Flush();
 				}
 			}
@@ -222,7 +222,7 @@ namespace ModernDiskQueue.Tests
 			{
 				using (var session = queue.OpenSession())
 				{
-					Assert.IsNull(session.Dequeue());// the last transaction was corrupted
+					Assert.That(session.Dequeue(), Is.Null);// the last transaction was corrupted
 					session.Flush();
 				}
 			}
@@ -257,7 +257,7 @@ namespace ModernDiskQueue.Tests
 	        {
 	            using (var session = queue.OpenSession())
 	            {
-	                Assert.IsNull(session.Dequeue());// the last transaction was corrupted
+	                Assert.That(session.Dequeue(), Is.Null);// the last transaction was corrupted
 	                session.Flush();
 	            }
 	        }
@@ -292,7 +292,7 @@ namespace ModernDiskQueue.Tests
 	        {
 	            using (var session = queue.OpenSession())
 	            {
-	                Assert.IsNull(session.Dequeue());// the last transaction was corrupted
+	                Assert.That(session.Dequeue(), Is.Null);// the last transaction was corrupted
 	                session.Flush();
 	            }
 	        }
@@ -325,7 +325,7 @@ namespace ModernDiskQueue.Tests
 	                {
 	                    Assert.IsEmpty(session.Dequeue());
 	                }
-	                Assert.IsNull(session.Dequeue());
+	                Assert.That(session.Dequeue(), Is.Null);
 	                session.Flush();
 	            }
 	        }
@@ -412,7 +412,7 @@ namespace ModernDiskQueue.Tests
 	            {
 	                for (int j = 0; j < 20; j++)
 	                {
-	                    Assert.IsNotNull(session.Dequeue());
+	                    Assert.That(session.Dequeue(), Is.Not.Null);
 	                    session.Flush();
 	                }
 	            }
@@ -445,7 +445,7 @@ namespace ModernDiskQueue.Tests
 	            {
 	                for (int j = 0; j < 20; j++)
 	                {
-	                    Assert.IsNotNull(session.Dequeue());
+	                    Assert.That(session.Dequeue(), Is.Not.Null);
 	                    session.Flush();
 	                }
 	            }
@@ -496,7 +496,7 @@ namespace ModernDiskQueue.Tests
 		                session.Flush();
 	                }
 	                
-	                Assert.IsNull(session.Dequeue());
+	                Assert.That(session.Dequeue(), Is.Null);
 	                session.Flush();
 	            }
 	        }
@@ -536,9 +536,9 @@ namespace ModernDiskQueue.Tests
 	            {
 	                for (int j = 0; j < 5; j++) // first 5 should be OK
 	                {
-	                    Assert.IsNotNull(session.Dequeue());
+	                    Assert.That(session.Dequeue(), Is.Not.Null);
 	                }
-	                Assert.IsNull(session.Dequeue()); // duplicated 5 should be silently lost.
+	                Assert.That(session.Dequeue(), Is.Null); // duplicated 5 should be silently lost.
 	                session.Flush();
 	            }
 	        }

--- a/src/ModernDiskQueue.Tests/TransactionLogTests.cs
+++ b/src/ModernDiskQueue.Tests/TransactionLogTests.cs
@@ -41,7 +41,7 @@ namespace ModernDiskQueue.Tests
 				txSizeWhenOpen = txLogInfo.Length;
 			}
 			txLogInfo.Refresh();
-			Assert.Less(txLogInfo.Length, txSizeWhenOpen);
+			Assert.That(txLogInfo.Length, Is.LessThan(txSizeWhenOpen));
 		}
 
 		[Test]
@@ -148,7 +148,7 @@ namespace ModernDiskQueue.Tests
 				session.Flush();
 			}
 			txLogInfo.Refresh();
-			Assert.Less(txLogInfo.Length, txSizeWhenOpen);
+			Assert.That(txLogInfo.Length, Is.LessThan(txSizeWhenOpen));
 		}
 
 		[Test]
@@ -323,7 +323,7 @@ namespace ModernDiskQueue.Tests
 	            {
 	                for (int j = 0; j < 20; j++)
 	                {
-	                    Assert.IsEmpty(session.Dequeue());
+	                    Assert.That(session.Dequeue(), Is.Empty);
 	                }
 	                Assert.That(session.Dequeue(), Is.Null);
 	                session.Flush();

--- a/src/ModernDiskQueue.Tests/TransactionLogTests.cs
+++ b/src/ModernDiskQueue.Tests/TransactionLogTests.cs
@@ -72,7 +72,7 @@ namespace ModernDiskQueue.Tests
 			}
 			using (var queue = new PersistentQueue(Path))
 			{
-				Assert.AreEqual(10, queue.EstimatedCountOfItemsInQueue);
+				Assert.That(10, Is.EqualTo(queue.EstimatedCountOfItemsInQueue));
 			}
 		}
 
@@ -185,7 +185,7 @@ namespace ModernDiskQueue.Tests
 					for (int j = 0; j < 19; j++)
 					{
 						var bytes = session.Dequeue() ?? throw new Exception("read failed");
-						Assert.AreEqual(j, BitConverter.ToInt32(bytes, 0));
+						Assert.That(j, Is.EqualTo(BitConverter.ToInt32(bytes, 0)));
 					}
 					Assert.IsNull(session.Dequeue());// the last transaction was corrupted
 					session.Flush();
@@ -353,7 +353,7 @@ namespace ModernDiskQueue.Tests
 	        {
 	            using (var session = queue.OpenSession())
 	            {
-	                Assert.AreEqual(Constants.EndTransactionSeparator, session.Dequeue());
+	                Assert.That(Constants.EndTransactionSeparator, Is.EqualTo(session.Dequeue()));
 	                session.Flush();
 	            }
 	        }
@@ -381,7 +381,7 @@ namespace ModernDiskQueue.Tests
 	        {
 	            using (var session = queue.OpenSession())
 	            {
-	                Assert.AreEqual(Constants.StartTransactionSeparator, session.Dequeue());
+	                Assert.That(Constants.StartTransactionSeparator, Is.EqualTo(session.Dequeue()));
 	                session.Flush();
 	            }
 	        }
@@ -475,7 +475,7 @@ namespace ModernDiskQueue.Tests
 	        {
                 var buf = new byte[(int)txLog.Length];
 	            var actual = txLog.Read(buf, 0, (int)txLog.Length);
-	            Assert.AreEqual(txLog.Length, actual);
+	            Assert.That(txLog.Length, Is.EqualTo(actual));
 	            txLog.Write(buf, 0, buf.Length);        // a 'good' extra session
 	            txLog.Write(buf, 0, buf.Length / 2);    // a 'bad' extra session
 	            txLog.Flush();
@@ -524,7 +524,7 @@ namespace ModernDiskQueue.Tests
 	        {
 	            var buf = new byte[(int)txLog.Length];
 	            var actual = txLog.Read(buf, 0, (int)txLog.Length);
-	            Assert.AreEqual(txLog.Length, actual);
+	            Assert.That(txLog.Length, Is.EqualTo(actual));
 	            txLog.Write(buf, 0, buf.Length - 16); // new session, but with missing end marker
 	            txLog.Write(Constants.StartTransactionSeparator, 0, 16);
 	            txLog.Flush();
@@ -571,7 +571,7 @@ namespace ModernDiskQueue.Tests
 
 			txLogInfo.Refresh();
 
-			Assert.AreEqual(36, txLogInfo.Length);//empty transaction size
+			Assert.That(36, Is.EqualTo(txLogInfo.Length));//empty transaction size
 		}
 
 		[Test]
@@ -633,7 +633,7 @@ namespace ModernDiskQueue.Tests
 			{
 				if (expected == 19)
 					continue;
-				Assert.AreEqual(expected, data[i]);
+				Assert.That(expected, Is.EqualTo(data[i]));
 				expected++;
 			}
 		}

--- a/src/ModernDiskQueue.Tests/TrimmedHostTests.cs
+++ b/src/ModernDiskQueue.Tests/TrimmedHostTests.cs
@@ -44,7 +44,7 @@ namespace ModernDiskQueue.Tests
                 CreateNoWindow = true,
             };
 
-            Assert.IsTrue(File.Exists(path), "Checking that file exists: TestTrimmedExecutable.exe.");
+            Assert.That(File.Exists(path), Is.True, "Checking that file exists: TestTrimmedExecutable.exe.");
 
             try
             {
@@ -68,7 +68,7 @@ namespace ModernDiskQueue.Tests
                     }
 
                     Assert.IsNotEmpty(stdOut, "Executable did not return any data.");
-                    Assert.IsTrue(DateTimeOffset.TryParse(stdOut, out DateTimeOffset returnedValue), "Could not parse returned value.");
+                    Assert.That(DateTimeOffset.TryParse(stdOut, out DateTimeOffset returnedValue), Is.True, "Could not parse returned value.");
                     Assert.That(inputDate, Is.EqualTo(returnedValue), "Returned value did not match input.");
                 }
             }
@@ -103,7 +103,7 @@ namespace ModernDiskQueue.Tests
                 CreateNoWindow = true,
             };
 
-            Assert.IsTrue(File.Exists(path), "Checking that file exists: TestTrimmedExecutable.exe.");
+            Assert.That(File.Exists(path), Is.True, "Checking that file exists: TestTrimmedExecutable.exe.");
 
             try
             {
@@ -127,7 +127,7 @@ namespace ModernDiskQueue.Tests
                     }
 
                     Assert.IsNotEmpty(stdOut, "Executable did not return any data.");
-                    Assert.IsTrue(int.TryParse(stdOut, out int returnedValue), "Could not parse output value from executable.");
+                    Assert.That(int.TryParse(stdOut, out int returnedValue), Is.True, "Could not parse output value from executable.");
                     Assert.That(argument, Is.EqualTo(returnedValue), "Return value did not match input.");
                 }
             }

--- a/src/ModernDiskQueue.Tests/TrimmedHostTests.cs
+++ b/src/ModernDiskQueue.Tests/TrimmedHostTests.cs
@@ -67,7 +67,7 @@ namespace ModernDiskQueue.Tests
                         Assert.Pass($"Executable returned an error: {stdErr}");
                     }
 
-                    Assert.IsNotEmpty(stdOut, "Executable did not return any data.");
+                    Assert.That(stdOut, Is.Not.Empty, "Executable did not return any data.");
                     Assert.That(DateTimeOffset.TryParse(stdOut, out DateTimeOffset returnedValue), Is.True, "Could not parse returned value.");
                     Assert.That(inputDate, Is.EqualTo(returnedValue), "Returned value did not match input.");
                 }
@@ -126,7 +126,7 @@ namespace ModernDiskQueue.Tests
                         Assert.Fail($"Executable returned an error: {stdErr}");
                     }
 
-                    Assert.IsNotEmpty(stdOut, "Executable did not return any data.");
+                    Assert.That(stdOut, Is.Not.Empty, "Executable did not return any data.");
                     Assert.That(int.TryParse(stdOut, out int returnedValue), Is.True, "Could not parse output value from executable.");
                     Assert.That(argument, Is.EqualTo(returnedValue), "Return value did not match input.");
                 }


### PR DESCRIPTION
Updated the testing packages, including nunit, nsubstituted, the adapter and microsoft test sdk packages. Modified syntax of assertions to use the new convention. All tests pass.