### PR TITLE
Narrowing lock scope

### DIFF
--- a/src/ModernDiskQueue.Benchmarks/ContentiousEnqueues.cs
+++ b/src/ModernDiskQueue.Benchmarks/ContentiousEnqueues.cs
@@ -151,7 +151,6 @@
 
                                 while (count > 0)
                                 {
-
                                     // Smart backoff for lock acquisition
                                     var retryCount = threadRetries.AddOrUpdate(threadId, 0, (_, c) => c + 1);
                                     if (retryCount > 0)
@@ -237,12 +236,6 @@
                 }
                 enqueueCompleted.Dispose();
             }
-        }
-
-        public void RunAsyncInThread(Func<Task> asyncFunc)
-        {
-            var t = asyncFunc();
-            t.GetAwaiter().GetResult();
         }
 
         [Benchmark]
@@ -391,6 +384,12 @@
                 }
                 enqueueCompleted.Dispose();
             }
+        }
+
+        public void RunAsyncInThread(Func<Task> asyncFunc)
+        {
+            var t = asyncFunc();
+            t.GetAwaiter().GetResult();
         }
     }
 }

--- a/src/ModernDiskQueue.Tests/ThreadSafeAccessTestsAsync.cs
+++ b/src/ModernDiskQueue.Tests/ThreadSafeAccessTestsAsync.cs
@@ -116,7 +116,7 @@
         [Test]
         public async Task can_enqueue_and_dequeue_on_separate_threads_v2()
         {
-            const int timeoutSeconds = 30;
+            const int timeoutSeconds = 50;
             const int target = 100;
 
             var producerTcs = new TaskCompletionSource<bool>();
@@ -439,6 +439,12 @@
 
             Assert.That(t1s, Is.EqualTo(target));
             Assert.That(t2s, Is.EqualTo(target));
+        }
+
+        public void RunAsyncInThread(Func<Task> asyncFunc)
+        {
+            var t = asyncFunc();
+            t.GetAwaiter().GetResult();
         }
     }
 }

--- a/src/ModernDiskQueue/Implementation/Constants.cs
+++ b/src/ModernDiskQueue/Implementation/Constants.cs
@@ -30,6 +30,9 @@ namespace ModernDiskQueue.Implementation
 
         /// <summary> 32MiB in bytes </summary>
         public const int _32Megabytes = 32*1024*1024;
+
+        /// <summary> 64MiB in bytes </summary>
+        public const int _64Megabytes = 64*1024*1024;
     }
 
     /// <summary>


### PR DESCRIPTION
Replaced using of HashSet and AsyncLock pattern with a concurrentdiionary collection, similar with a dictionary for countofitemsperfile. Reworked the disposal flag in async methods and used a semaphorslim directly instead of using AsyncLock class just to lighten things up.
Still running about four times slower than I'd like. Dequeueasync's use of a lock on the _entries collection is probably what needs a hard look - rethinking use of collection entirely.