### PR TITLE
Fixed bug affecting linux installations

### DIFF
--- a/src/ModernDiskQueue/Implementation/StandardFileDriver.cs
+++ b/src/ModernDiskQueue/Implementation/StandardFileDriver.cs
@@ -614,8 +614,8 @@
         /// </summary>
         private bool Move_UnderLock(string oldPath, string newPath, CancellationToken cancellationToken = default)
         {
-            string oldFileName = oldPath[oldPath.LastIndexOf('\\')..];
-            string newFileName = newPath[newPath.LastIndexOf('\\')..];
+            string oldFileName = Path.GetFileName(oldPath);
+            string newFileName = Path.GetFileName(newPath);
             for (var i = 0; i < RetryLimit; i++)
             {
                 cancellationToken.ThrowIfCancellationRequested();

--- a/src/ModernDiskQueue/ModernDiskQueue.csproj
+++ b/src/ModernDiskQueue/ModernDiskQueue.csproj
@@ -9,7 +9,7 @@
     <PackageTags>net8</PackageTags>
     <PackageTags>queue;disk;persistent;net8;modern</PackageTags>
     <PackageProjectUrl>https://github.com/pracsol/ModernDiskQueue</PackageProjectUrl>
-    <Version>3.0.1-rc1</Version>
+    <Version>3.0.1-rc.1</Version>
     <AssemblyName>ModernDiskQueue</AssemblyName>
     <LangVersion>12</LangVersion>
     <RepositoryUrl>https://github.com/pracsol/ModernDiskQueue</RepositoryUrl>

--- a/src/ModernDiskQueue/ModernDiskQueue.csproj
+++ b/src/ModernDiskQueue/ModernDiskQueue.csproj
@@ -9,7 +9,7 @@
     <PackageTags>net8</PackageTags>
     <PackageTags>queue;disk;persistent;net8;modern</PackageTags>
     <PackageProjectUrl>https://github.com/pracsol/ModernDiskQueue</PackageProjectUrl>
-    <Version>3.0.0</Version>
+    <Version>3.0.1-rc1</Version>
     <AssemblyName>ModernDiskQueue</AssemblyName>
     <LangVersion>12</LangVersion>
     <RepositoryUrl>https://github.com/pracsol/ModernDiskQueue</RepositoryUrl>


### PR DESCRIPTION
The session flushing operation was causing an exception when running on linux. 

This was traced to the standardfiledriver using string parsing to determine the file name in the method Move_UnderLock. It was looking for an escaped backslash character in the path, and in linux of course it's going to be a forward slash. So LastIndexOf was returning -1, causing an exception in the range operator. See exception details below.
This operation has been changed to use the system.io library methods to get the file names, which offer cleaner cross-platform support than adjusting the manual parsing.
```bash
[7419]: System.ArgumentOutOfRangeException: startIndex ('-1') must be a non-negative value. (Parameter 'startIndex')
[7419]: Actual value was -1.
[7419]:    at System.ArgumentOutOfRangeException.ThrowNegative[T](T, String)
[7419]:    at System.String.ThrowSubstringArgumentOutOfRange(Int32 startIndex, Int32 length)
[7419]:    at System.String.Substring(Int32 startIndex, Int32 length)
[7419]:    at ModernDiskQueue.Implementation.StandardFileDriver.Move_UnderLock(String oldPath, String newPath, CancellationToken cancellationToken)
[7419]:    at ModernDiskQueue.Implementation.StandardFileDriver.MoveAsync(String oldPath, String newPath, CancellationToken cancellationToken)
[7419]:    at ModernDiskQueue.Implementation.StandardFileDriver.AtomicWriteInternalAsync(String path, Func`2 action, CancellationToken cancellationToken)
[7419]:    at ModernDiskQueue.Implementation.StandardFileDriver.AtomicWriteAsync(String path, Func`2 action, CancellationToken cancellationToken)
[7419]:    at ModernDiskQueue.Implementation.PersistentQueueImpl.CommitTransactionAsync(ICollection`1, CancellationToken )
[7419]:    at ModernDiskQueue.Implementation.PersistentQueueSession.FlushAsync(CancellationToken )
```